### PR TITLE
Add edge case tests for Gherkin parser

### DIFF
--- a/UnitTests.feature
+++ b/UnitTests.feature
@@ -86,3 +86,106 @@ Test Feature,Scenario: Test Scenario,Given a step
 ,,Then a final step
 ,,
 """
+
+Scenario: Test missing Feature keyword
+Given a feature file with the following content:
+"""
+Scenario: Test Scenario
+Given a step
+When another step
+Then a final step
+"""
+When the parse_feature_file function is called
+Then the output should be:
+"""
+[]
+"""
+
+Scenario: Test missing Scenario keyword
+Given a feature file with the following content:
+"""
+Feature: Test Feature
+Given a step
+When another step
+Then a final step
+"""
+When the parse_feature_file function is called
+Then the output should be:
+"""
+[
+    ['Test Feature', '', '']
+]
+"""
+
+Scenario: Test invalid step keywords
+Given a feature file with the following content:
+"""
+Feature: Test Feature
+Scenario: Test Scenario
+Giben a step
+Whan another step
+Then a final step
+"""
+When the parse_feature_file function is called
+Then the output should be:
+"""
+[
+    ['Test Feature', '', ''],
+    ['Test Feature', 'Scenario: Test Scenario', '']
+]
+"""
+
+Scenario: Test empty lines and lines with only whitespace
+Given a feature file with the following content:
+"""
+Feature: Test Feature
+
+Scenario: Test Scenario
+
+Given a step
+
+When another step
+
+Then a final step
+
+"""
+When the parse_feature_file function is called
+Then the output should be:
+"""
+[
+    ['Test Feature', '', ''],
+    ['Test Feature', 'Scenario: Test Scenario', ''],
+    ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+    ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
+    ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
+]
+"""
+
+Scenario: Test missing Scenario Outline keyword
+Given a feature file with the following content:
+"""
+Feature: Test Feature
+Scenario Outline: Test Scenario Outline
+Given a step
+When another step
+Then a final step
+Examples:
+| column 1 |
+| value 1  |
+| value 2  |
+"""
+When the parse_feature_file function is called
+Then the output should be:
+"""
+[
+    ['Test Feature', '', ''],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', ''],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Given a step'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'When another step'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Then a final step'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Examples:'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| column 1 |'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 1  |'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 2  |']
+]
+"""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,3 +17,86 @@ Then a final step
         ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
     ]
     assert parse_feature_file(feature_file) == expected_output
+
+def test_missing_feature_keyword():
+    feature_file_content = """Scenario: Test Scenario
+Given a step
+When another step
+Then a final step
+"""
+    feature_file = io.StringIO(feature_file_content)
+    expected_output = []
+    assert parse_feature_file(feature_file) == expected_output
+
+def test_missing_scenario_keyword():
+    feature_file_content = """Feature: Test Feature
+Given a step
+When another step
+Then a final step
+"""
+    feature_file = io.StringIO(feature_file_content)
+    expected_output = [
+        ['Test Feature', '', '']
+    ]
+    assert parse_feature_file(feature_file) == expected_output
+
+def test_invalid_step_keywords():
+    feature_file_content = """Feature: Test Feature
+Scenario: Test Scenario
+Giben a step
+Whan another step
+Then a final step
+"""
+    feature_file = io.StringIO(feature_file_content)
+    expected_output = [
+        ['Test Feature', '', ''],
+        ['Test Feature', 'Scenario: Test Scenario', '']
+    ]
+    assert parse_feature_file(feature_file) == expected_output
+
+def test_empty_lines_and_whitespace():
+    feature_file_content = """Feature: Test Feature
+
+Scenario: Test Scenario
+
+Given a step
+
+When another step
+
+Then a final step
+
+"""
+    feature_file = io.StringIO(feature_file_content)
+    expected_output = [
+        ['Test Feature', '', ''],
+        ['Test Feature', 'Scenario: Test Scenario', ''],
+        ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+        ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
+        ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
+    ]
+    assert parse_feature_file(feature_file) == expected_output
+
+def test_missing_scenario_outline_keyword():
+    feature_file_content = """Feature: Test Feature
+Scenario Outline: Test Scenario Outline
+Given a step
+When another step
+Then a final step
+Examples:
+| column 1 |
+| value 1  |
+| value 2  |
+"""
+    feature_file = io.StringIO(feature_file_content)
+    expected_output = [
+        ['Test Feature', '', ''],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', ''],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Given a step'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'When another step'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Then a final step'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Examples:'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| column 1 |'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 1  |'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 2  |']
+    ]
+    assert parse_feature_file(feature_file) == expected_output


### PR DESCRIPTION
Add tests for edge cases and error conditions in `tests/test_parser.py` and `UnitTests.feature`.

* **tests/test_parser.py**
  - Add test for missing `Feature:` keyword.
  - Add test for missing `Scenario:` keyword.
  - Add test for invalid step keywords.
  - Add test for empty lines and lines with only whitespace.
  - Add test for missing `Scenario Outline:` keyword.

* **UnitTests.feature**
  - Add scenario for missing `Feature:` keyword.
  - Add scenario for missing `Scenario:` keyword.
  - Add scenario for invalid step keywords.
  - Add scenario for empty lines and lines with only whitespace.
  - Add scenario for missing `Scenario Outline:` keyword.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/8?shareId=c38db89b-01e3-4e79-a2cc-fa372c4e2432).