### PR TITLE
Add validation for 'Scenario Outline' followed by examples table

### DIFF
--- a/UnitTests.feature
+++ b/UnitTests.feature
@@ -86,3 +86,32 @@ Test Feature,Scenario: Test Scenario,Given a step
 ,,Then a final step
 ,,
 """
+
+Scenario: Test Scenario Outline followed by Examples
+Given a feature file with the following content:
+"""
+Feature: Test Feature
+Scenario Outline: Test Scenario Outline
+Given a step
+When another step
+Then a final step
+Examples:
+| column 1 |
+| value 1  |
+| value 2  |
+"""
+When the parse_feature_file function is called
+Then the output should be:
+"""
+[
+    ['Test Feature', '', ''],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', ''],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Given a step'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'When another step'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Then a final step'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Examples:'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| column 1 |'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 1  |'],
+    ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 2  |']
+]
+"""

--- a/format_checker.py
+++ b/format_checker.py
@@ -3,6 +3,9 @@ def check_formatting(file_path):
         lines = file.readlines()
 
     errors = []
+    scenario_outline = False
+    examples_table = False
+
     for i, line in enumerate(lines):
         line = line.strip()
         if not any(line.startswith(keyword) for keyword in
@@ -10,6 +13,13 @@ def check_formatting(file_path):
                     'Scenario Outline:', 'Developer Task:', 'Given', 'And',
                     'When', 'Then']):
             errors.append(f"Formatting error on line {i + 1}: {line}")
+        if line.startswith('Scenario Outline:'):
+            scenario_outline = True
+            examples_table = False
+        if line.startswith('Examples:'):
+            examples_table = True
+        if line.startswith('|') and scenario_outline and not examples_table:
+            errors.append(f"Formatting error on line {i + 1}: 'Scenario Outline' must be followed by an examples table with lines 'Examples:' and '|'")
 
     if errors:
         return "\n".join(errors)

--- a/gherkin_parser.py
+++ b/gherkin_parser.py
@@ -5,6 +5,8 @@ def parse_feature_file(file_path):
     features = []
     current_feature = None
     current_scenario = None
+    scenario_outline = False
+    examples_table = False
 
     for line_number, line in enumerate(lines, start=1):
         line = line.lstrip()
@@ -20,10 +22,17 @@ def parse_feature_file(file_path):
                 features.append([current_feature, '', ''])
             if current_feature and current_scenario:
                 features.append([current_feature, current_scenario, ''])
+            if line.startswith('Scenario Outline:'):
+                scenario_outline = True
+                examples_table = False
         elif any(line.startswith(keyword) for keyword in
                  ['Given', 'When', 'Then', 'And', 'Examples', '|']):
             if current_feature and current_scenario:
                 features.append([current_feature, current_scenario, line])
+            if line.startswith('Examples:'):
+                examples_table = True
+            if line.startswith('|') and scenario_outline and not examples_table:
+                print(f"Invalid Gherkin syntax at line {line_number}: 'Scenario Outline' must be followed by an examples table with lines 'Examples:' and '|'")
         elif line:
             print(f"Invalid Gherkin syntax at line {line_number}: {line}")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,3 +17,28 @@ Then a final step
         ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
     ]
     assert parse_feature_file(feature_file) == expected_output
+
+def test_scenario_outline_followed_by_examples():
+    feature_file_content = """Feature: Test Feature
+Scenario Outline: Test Scenario Outline
+Given a step
+When another step
+Then a final step
+Examples:
+| column 1 |
+| value 1  |
+| value 2  |
+"""
+    feature_file = io.StringIO(feature_file_content)
+    expected_output = [
+        ['Test Feature', '', ''],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', ''],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Given a step'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'When another step'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Then a final step'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Examples:'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| column 1 |'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 1  |'],
+        ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 2  |']
+    ]
+    assert parse_feature_file(feature_file) == expected_output


### PR DESCRIPTION
Add validation to ensure 'Scenario Outline' is followed by an examples table with lines 'Examples:' and '|'.

* **gherkin_parser.py**
  - Add validation logic to check if 'Scenario Outline' is followed by an examples table with lines 'Examples:' and '|'.
  - Update `parse_feature_file` function to include the validation logic.

* **format_checker.py**
  - Add check to ensure 'Scenario Outline' is followed by an examples table with lines 'Examples:' and '|'.
  - Update `check_formatting` function to include the validation logic.

* **tests/test_parser.py**
  - Add a test to ensure 'Scenario Outline' is followed by an examples table with lines 'Examples:' and '|'.
  - Update `test_parse_feature_file` function to include the new test case.

* **UnitTests.feature**
  - Add a scenario to test 'Scenario Outline' followed by an examples table with lines 'Examples:' and '|'.
  - Update `UnitTests.feature` to include the new scenario.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/9?shareId=4372daa1-bd5b-4e54-8b7d-dd309d4b52fb).