### PR TITLE
Remove spellchecker from Gherkin parser and inspection script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ output_csv_path = config.get_output_csv_path()
    python inspectFeature.py <feature_file_path>
    ```
 
-5. The script will display a summary of any formatting errors, spelling mistakes, or syntax issues found in the feature file.
-6. The script will ask if you would like to continue with CSV generation despite these issues. Use standard input (`input()`) to capture your decision.
+5. The script will display a summary of any formatting errors or syntax issues found in the feature file.
 
 ## Running Tests
 

--- a/gherkin_parser.py
+++ b/gherkin_parser.py
@@ -1,11 +1,4 @@
 import re
-from spellchecker import SpellChecker
-
-def check_spelling(text):
-    spell = SpellChecker()
-    words = re.findall(r'\b\w+\b', text)
-    misspelled = spell.unknown(words)
-    return list(misspelled)
 
 def parse_feature_file(file_path):
     with open(file_path, 'r') as file:
@@ -46,11 +39,6 @@ def parse_feature_file(file_path):
                 errors.append(f"Invalid Gherkin syntax at line {line_number}: 'Scenario Outline' must be followed by an examples table with lines 'Examples:' and '|'")
         elif line:
             errors.append(f"Invalid Gherkin syntax at line {line_number}: {line}")
-
-        # Check for spelling mistakes
-        misspelled_words = check_spelling(line)
-        if misspelled_words:
-            warnings.append(f"Spelling mistakes at line {line_number}: {', '.join(misspelled_words)}")
 
     return {
         'features': features,

--- a/inspectFeature.py
+++ b/inspectFeature.py
@@ -19,10 +19,10 @@ def main():
         for warning in feature_data['warnings']:
             print(warning)
 
-    if feature_data['errors'] or feature_data['warnings']:
+    if feature_data['errors']:
         decision = input("Would you like to continue with CSV generation despite these issues? (yes/no): ")
         if decision.lower() != 'yes':
-            print("CSV generation aborted due to errors or warnings.")
+            print("CSV generation aborted due to errors.")
             sys.exit(1)
 
     print("No critical issues found. You can proceed with CSV generation.")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
 import io
-from gherkin_parser import parse_feature_file, check_spelling
+from gherkin_parser import parse_feature_file
 
 def test_parse_feature_file():
     feature_file_content = """Feature: Test Feature
@@ -50,8 +50,3 @@ Examples:
         'warnings': []
     }
     assert parse_feature_file(feature_file) == expected_output
-
-def test_check_spelling():
-    text = "This is a smple text with a speling mistake."
-    expected_output = ['smple', 'speling']
-    assert check_spelling(text) == expected_output


### PR DESCRIPTION
Remove the spellchecker functionality from the codebase.

* **gherkin_parser.py**
  - Remove the import statement for `SpellChecker`.
  - Remove the `check_spelling` function.
  - Remove the call to `check_spelling` and the `warnings` list update.

* **inspectFeature.py**
  - Remove the display of spelling mistakes from `feature_data['warnings']`.
  - Remove the prompt to continue despite spelling issues.

* **README.md**
  - Remove references to spelling mistakes in the inspection script.

* **tests/test_parser.py**
  - Remove the `test_check_spelling` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/12?shareId=9d36af01-ec15-4eef-84d8-0d6b26c79a36).