### PR TITLE
Add user confirmation before writing CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A tool for extracting Test Cases, and Steps ready to be entered into Fibery
    python Gherkin2Fibery.py <feature_file_path>
    ```
 
+5. After the script checks the formatting and parses the feature file, it will prompt you to confirm whether you want to continue and write the CSV file. Type `yes` to proceed or `no` to cancel the operation.
+
 ### Configuration Management
 
 The script now uses a `Config` class to manage file paths and command-line arguments. This class is defined in the `config.py` file.

--- a/main.py
+++ b/main.py
@@ -16,9 +16,14 @@ def main():
         print(formatting_result)
 
     feature_data = parse_feature_file(feature_file_path)
-    write_to_csv(feature_data, output_csv_path)
 
-    print(f"Successfully converted Gherkin file to CSV: {output_csv_path}")
+    user_input = input("Do you want to continue and write the CSV file? (yes/no): ")
+    if user_input.lower() == 'yes':
+        write_to_csv(feature_data, output_csv_path)
+        print(f"Successfully converted Gherkin file to CSV: {output_csv_path}")
+    else:
+        print("Operation cancelled by the user.")
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add user confirmation before writing CSV file.

* **main.py**
  - Add user prompt to confirm continuation after formatting check.
  - Call `write_to_csv` only if user confirms continuation.
  - Exit script if user does not confirm continuation.

* **README.md**
  - Update usage instructions to include user confirmation step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/13?shareId=7a5f9add-9801-49cc-a2a7-03b7099196e6).