### PR TITLE
Fix inspectFeature.py to handle invalid Gherkin syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ output_csv_path = config.get_output_csv_path()
    python inspectFeature.py <feature_file_path>
    ```
 
-5. The script will display a summary of any formatting errors or syntax issues found in the feature file.
+5. The script will display a summary of any formatting errors or syntax issues found in the feature file. It will also handle non-numeric characters in error messages to avoid the ValueError.
 
 ### New Behavior of `inspectFeature.py`
 

--- a/inspectFeature.py
+++ b/inspectFeature.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from gherkin_parser import parse_feature_file, find_closest_match, update_feature_file
 
 def main():
@@ -15,15 +16,17 @@ def main():
             print(error)
 
         for error in feature_data['errors']:
-            line_number = int(error.split(' ')[-1].strip(':'))
-            line = error.split(': ')[-1]
-            closest_match = find_closest_match(line, feature_data['valid_keywords'])
-            if closest_match:
-                user_input = input(f"Did you mean '{closest_match}' instead of '{line}'? (yes/no): ")
-                if user_input.lower() == 'yes':
-                    update_feature_file(feature_file_path, line_number, closest_match)
-                    feature_data = parse_feature_file(feature_file_path)
-                    break
+            match = re.search(r'at line (\d+):', error)
+            if match:
+                line_number = int(match.group(1))
+                line = error.split(': ')[-1]
+                closest_match = find_closest_match(line, feature_data['valid_keywords'])
+                if closest_match:
+                    user_input = input(f"Did you mean '{closest_match}' instead of '{line}'? (yes/no): ")
+                    if user_input.lower() == 'yes':
+                        update_feature_file(feature_file_path, line_number, closest_match)
+                        feature_data = parse_feature_file(feature_file_path)
+                        break
         else:
             break
 


### PR DESCRIPTION
Update `inspectFeature.py` to handle invalid Gherkin syntax errors without causing a ValueError.

* Import the `re` module for regular expression handling.
* Update the `main` function to extract the line number from the error message using a regular expression.
* Handle non-numeric characters in error messages to avoid the ValueError.

Update `README.md` to reflect the changes in the `inspectFeature.py` script.

* Add a note about handling non-numeric characters in error messages to avoid the ValueError.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/18?shareId=efb9295f-70f0-4d27-8f86-8ce5a03c5ad1).