### PR TITLE
Add format checker module

### DIFF
--- a/format_checker.py
+++ b/format_checker.py
@@ -1,0 +1,12 @@
+import re
+
+def check_formatting(feature_file):
+    errors = []
+    valid_keywords = ['Feature:', 'Scenario:', 'Scenario Outline:', 'Developer Task:', 'Given', 'When', 'Then', 'And', 'Examples', '|']
+
+    for line_number, line in enumerate(feature_file, start=1):
+        line = line.lstrip()
+        if not any(line.startswith(keyword) for keyword in valid_keywords) and line:
+            errors.append(f"Formatting error on line {line_number}: {line}")
+
+    return errors


### PR DESCRIPTION
Add `format_checker.py` to resolve ImportError in `test_format_checker`.

* Add `format_checker.py` with `check_formatting` function to check the formatting of a feature file
* Import `re` module for regular expressions
* Return a list of formatting errors found in the feature file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/19?shareId=37d7bdfc-c51f-4b93-9513-941793cf6655).