### PR TITLE
Link and include test files with test cases derived from unittest.TestCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ To run the new test files that use `io.StringIO` for in-memory file-like objects
 python -m unittest discover -s tests -p "test_*.py"
 ```
 
+### Running Test Files
+
+The test files are located in the `tests` directory and contain test cases derived from `unittest.TestCase`. To run the test files using `unittest` and the `discover` command, use the following command:
+
+```sh
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+The test files included are:
+- `tests/test_csv_writer.py`
+- `tests/test_format_checker.py`
+- `tests/test_parser.py`
+
+These test files are now linked and included in the main codebase for automated testing or continuous integration.
+
 ## Additional Files
 
 - `gherkin_parser.py`: Contains the function to parse Gherkin feature files.

--- a/tests/test_csv_writer.py
+++ b/tests/test_csv_writer.py
@@ -1,20 +1,22 @@
 import io
 import csv
+import unittest
 from csv_writer import write_to_csv
 
-def test_write_to_csv():
-    data = [
-        ['Feature 1', 'Scenario: Test Scenario 1', 'Given a step'],
-        ['Feature 1', 'Scenario: Test Scenario 1', 'When another step'],
-        ['Feature 1', 'Scenario: Test Scenario 1', 'Then a final step'],
-        ['Feature 2', 'Scenario: Test Scenario 2', 'Given a step'],
-        ['Feature 2', 'Scenario: Test Scenario 2', 'When another step'],
-        ['Feature 2', 'Scenario: Test Scenario 2', 'Then a final step']
-    ]
-    output = io.StringIO()
-    write_to_csv(data, output)
-    output.seek(0)
-    expected_output = """Scenarios
+class TestCsvWriter(unittest.TestCase):
+    def test_write_to_csv(self):
+        data = [
+            ['Feature 1', 'Scenario: Test Scenario 1', 'Given a step'],
+            ['Feature 1', 'Scenario: Test Scenario 1', 'When another step'],
+            ['Feature 1', 'Scenario: Test Scenario 1', 'Then a final step'],
+            ['Feature 2', 'Scenario: Test Scenario 2', 'Given a step'],
+            ['Feature 2', 'Scenario: Test Scenario 2', 'When another step'],
+            ['Feature 2', 'Scenario: Test Scenario 2', 'Then a final step']
+        ]
+        output = io.StringIO()
+        write_to_csv(data, output)
+        output.seek(0)
+        expected_output = """Scenarios
 Scenario: Test Scenario 1
 Scenario: Test Scenario 2
 Feature,Test Case/Scenario,Test Step
@@ -27,4 +29,7 @@ Feature 2,Scenario: Test Scenario 2,Given a step
 ,,Then a final step
 ,,
 """
-    assert output.getvalue() == expected_output
+        self.assertEqual(output.getvalue(), expected_output)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_format_checker.py
+++ b/tests/test_format_checker.py
@@ -1,14 +1,19 @@
 import io
+import unittest
 from format_checker import check_formatting
 
-def test_check_formatting():
-    feature_file_content = """Feature: Test Feature
+class TestFormatChecker(unittest.TestCase):
+    def test_check_formatting(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Given a step
 When another step
 Then a final step
 Invalid line
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = "Formatting error on line 6: Invalid line"
-    assert check_formatting(feature_file) == expected_output
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = "Formatting error on line 6: Invalid line"
+        self.assertEqual(check_formatting(feature_file), expected_output)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,29 +1,31 @@
 import io
+import unittest
 from gherkin_parser import parse_feature_file, find_closest_match, update_feature_file
 
-def test_parse_feature_file():
-    feature_file_content = """Feature: Test Feature
+class TestParser(unittest.TestCase):
+    def test_parse_feature_file(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Given a step
 When another step
 Then a final step
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [
-            ['Test Feature', '', ''],
-            ['Test Feature', 'Scenario: Test Scenario', ''],
-            ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
-            ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
-            ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
-        ],
-        'errors': [],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [
+                ['Test Feature', '', ''],
+                ['Test Feature', 'Scenario: Test Scenario', ''],
+                ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+                ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
+                ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
+            ],
+            'errors': [],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_scenario_outline_followed_by_examples():
-    feature_file_content = """Feature: Test Feature
+    def test_scenario_outline_followed_by_examples(self):
+        feature_file_content = """Feature: Test Feature
 Scenario Outline: Test Scenario Outline
 Given a step
 When another step
@@ -33,79 +35,79 @@ Examples:
 | value 1  |
 | value 2  |
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [
-            ['Test Feature', '', ''],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', ''],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Given a step'],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'When another step'],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Then a final step'],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Examples:'],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| column 1 |'],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 1  |'],
-            ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 2  |']
-        ],
-        'errors': [],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [
+                ['Test Feature', '', ''],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', ''],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Given a step'],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'When another step'],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Then a final step'],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', 'Examples:'],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| column 1 |'],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 1  |'],
+                ['Test Feature', 'Scenario Outline: Test Scenario Outline', '| value 2  |']
+            ],
+            'errors': [],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_missing_feature_keyword():
-    feature_file_content = """Scenario: Test Scenario
+    def test_missing_feature_keyword(self):
+        feature_file_content = """Scenario: Test Scenario
 Given a step
 When another step
 Then a final step
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [],
-        'errors': ["Invalid Gherkin syntax at line 1: Scenario: Test Scenario"],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [],
+            'errors': ["Invalid Gherkin syntax at line 1: Scenario: Test Scenario"],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_missing_scenario_keyword():
-    feature_file_content = """Feature: Test Feature
+    def test_missing_scenario_keyword(self):
+        feature_file_content = """Feature: Test Feature
 Given a step
 When another step
 Then a final step
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [['Test Feature', '', '']],
-        'errors': [
-            "Invalid Gherkin syntax at line 2: Given a step",
-            "Invalid Gherkin syntax at line 3: When another step",
-            "Invalid Gherkin syntax at line 4: Then a final step"
-        ],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [['Test Feature', '', '']],
+            'errors': [
+                "Invalid Gherkin syntax at line 2: Given a step",
+                "Invalid Gherkin syntax at line 3: When another step",
+                "Invalid Gherkin syntax at line 4: Then a final step"
+            ],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_invalid_step_keywords():
-    feature_file_content = """Feature: Test Feature
+    def test_invalid_step_keywords(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Giben a step
 Whan another step
 Then a final step
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [
-            ['Test Feature', '', ''],
-            ['Test Feature', 'Scenario: Test Scenario', '']
-        ],
-        'errors': [
-            "Invalid Gherkin syntax at line 3: Giben a step",
-            "Invalid Gherkin syntax at line 4: Whan another step"
-        ],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [
+                ['Test Feature', '', ''],
+                ['Test Feature', 'Scenario: Test Scenario', '']
+            ],
+            'errors': [
+                "Invalid Gherkin syntax at line 3: Giben a step",
+                "Invalid Gherkin syntax at line 4: Whan another step"
+            ],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_empty_lines_and_whitespace():
-    feature_file_content = """Feature: Test Feature
+    def test_empty_lines_and_whitespace(self):
+        feature_file_content = """Feature: Test Feature
 
 Scenario: Test Scenario
 
@@ -116,22 +118,22 @@ When another step
 Then a final step
 
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [
-            ['Test Feature', '', ''],
-            ['Test Feature', 'Scenario: Test Scenario', ''],
-            ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
-            ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
-            ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
-        ],
-        'errors': [],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [
+                ['Test Feature', '', ''],
+                ['Test Feature', 'Scenario: Test Scenario', ''],
+                ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+                ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
+                ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
+            ],
+            'errors': [],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_missing_scenario_outline_keyword():
-    feature_file_content = """Feature: Test Feature
+    def test_missing_scenario_outline_keyword(self):
+        feature_file_content = """Feature: Test Feature
 Given a step
 When another step
 Then a final step
@@ -140,107 +142,110 @@ Examples:
 | value 1  |
 | value 2  |
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [['Test Feature', '', '']],
-        'errors': [
-            "Invalid Gherkin syntax at line 2: Given a step",
-            "Invalid Gherkin syntax at line 3: When another step",
-            "Invalid Gherkin syntax at line 4: Then a final step",
-            "Invalid Gherkin syntax at line 5: Examples:",
-            "Invalid Gherkin syntax at line 6: | column 1 |",
-            "Invalid Gherkin syntax at line 7: | value 1  |",
-            "Invalid Gherkin syntax at line 8: | value 2  |"
-        ],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [['Test Feature', '', '']],
+            'errors': [
+                "Invalid Gherkin syntax at line 2: Given a step",
+                "Invalid Gherkin syntax at line 3: When another step",
+                "Invalid Gherkin syntax at line 4: Then a final step",
+                "Invalid Gherkin syntax at line 5: Examples:",
+                "Invalid Gherkin syntax at line 6: | column 1 |",
+                "Invalid Gherkin syntax at line 7: | value 1  |",
+                "Invalid Gherkin syntax at line 8: | value 2  |"
+            ],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_invalid_gherkin_syntax():
-    feature_file_content = """Feature: Test Feature
+    def test_invalid_gherkin_syntax(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Given a step
 Invalid line
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = [
-        ['Test Feature', '', ''],
-        ['Test Feature', 'Scenario: Test Scenario', ''],
-        ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
-        ['Test Feature', 'Scenario: Test Scenario', 'Invalid Gherkin syntax at line 4: Invalid line']
-    ]
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = [
+            ['Test Feature', '', ''],
+            ['Test Feature', 'Scenario: Test Scenario', ''],
+            ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+            ['Test Feature', 'Scenario: Test Scenario', 'Invalid Gherkin syntax at line 4: Invalid line']
+        ]
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_missing_elements():
-    feature_file_content = """Feature: Test Feature
+    def test_missing_elements(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = [
-        ['Test Feature', '', ''],
-        ['Test Feature', 'Scenario: Test Scenario', '']
-    ]
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = [
+            ['Test Feature', '', ''],
+            ['Test Feature', 'Scenario: Test Scenario', '']
+        ]
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_incorrect_formatting():
-    feature_file_content = """Feature: Test Feature
+    def test_incorrect_formatting(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Given a step
 When another step
 Then a final step
 1Scenario: Different formatting
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = [
-        ['Test Feature', '', ''],
-        ['Test Feature', 'Scenario: Test Scenario', ''],
-        ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
-        ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
-        ['Test Feature', 'Scenario: Test Scenario', 'Then a final step'],
-        ['Test Feature', 'Scenario: Test Scenario', 'Invalid Gherkin syntax at line 6: 1Scenario: Different formatting']
-    ]
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = [
+            ['Test Feature', '', ''],
+            ['Test Feature', 'Scenario: Test Scenario', ''],
+            ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+            ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
+            ['Test Feature', 'Scenario: Test Scenario', 'Then a final step'],
+            ['Test Feature', 'Scenario: Test Scenario', 'Invalid Gherkin syntax at line 6: 1Scenario: Different formatting']
+        ]
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
 
-def test_find_closest_match():
-    line = "Giben a step"
-    valid_keywords = ['Feature:', 'Scenario:', 'Scenario Outline:', 'Developer Task:', 'Given', 'When', 'Then', 'And', 'Examples', '|']
-    expected_output = "Given"
-    assert find_closest_match(line, valid_keywords) == expected_output
+    def test_find_closest_match(self):
+        line = "Giben a step"
+        valid_keywords = ['Feature:', 'Scenario:', 'Scenario Outline:', 'Developer Task:', 'Given', 'When', 'Then', 'And', 'Examples', '|']
+        expected_output = "Given"
+        self.assertEqual(find_closest_match(line, valid_keywords), expected_output)
 
-def test_update_feature_file():
-    feature_file_content = """Feature: Test Feature
+    def test_update_feature_file(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Giben a step
 When another step
 Then a final step
 """
-    feature_file = io.StringIO(feature_file_content)
-    update_feature_file(feature_file, 3, "Given a step")
-    expected_output = """Feature: Test Feature
+        feature_file = io.StringIO(feature_file_content)
+        update_feature_file(feature_file, 3, "Given a step")
+        expected_output = """Feature: Test Feature
 Scenario: Test Scenario
 Given a step
 When another step
 Then a final step
 """
-    assert feature_file.getvalue() == expected_output
+        self.assertEqual(feature_file.getvalue(), expected_output)
 
-def test_inspect_feature():
-    feature_file_content = """Feature: Test Feature
+    def test_inspect_feature(self):
+        feature_file_content = """Feature: Test Feature
 Scenario: Test Scenario
 Giben a step
 When another step
 Then a final step
 """
-    feature_file = io.StringIO(feature_file_content)
-    expected_output = {
-        'features': [
-            ['Test Feature', '', ''],
-            ['Test Feature', 'Scenario: Test Scenario', ''],
-            ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
-            ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
-            ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
-        ],
-        'errors': [],
-        'warnings': []
-    }
-    assert parse_feature_file(feature_file)['features'] == expected_output['features']
+        feature_file = io.StringIO(feature_file_content)
+        expected_output = {
+            'features': [
+                ['Test Feature', '', ''],
+                ['Test Feature', 'Scenario: Test Scenario', ''],
+                ['Test Feature', 'Scenario: Test Scenario', 'Given a step'],
+                ['Test Feature', 'Scenario: Test Scenario', 'When another step'],
+                ['Test Feature', 'Scenario: Test Scenario', 'Then a final step']
+            ],
+            'errors': [],
+            'warnings': []
+        }
+        self.assertEqual(parse_feature_file(feature_file)['features'], expected_output['features'])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Link and include test files with test cases derived from `unittest.TestCase`.

* **README.md**
  - Add instructions to run the test files using `unittest` and the `discover` command.
  - Mention the `tests` directory and the test files `tests/test_csv_writer.py`, `tests/test_format_checker.py`, and `tests/test_parser.py`.

* **tests/test_csv_writer.py**
  - Import `unittest` module.
  - Create a test class `TestCsvWriter` derived from `unittest.TestCase`.
  - Move the `test_write_to_csv` function inside the `TestCsvWriter` class.
  - Add `if __name__ == "__main__": unittest.main()` at the end of the file.

* **tests/test_format_checker.py**
  - Import `unittest` module.
  - Create a test class `TestFormatChecker` derived from `unittest.TestCase`.
  - Move the `test_check_formatting` function inside the `TestFormatChecker` class.
  - Add `if __name__ == "__main__": unittest.main()` at the end of the file.

* **tests/test_parser.py**
  - Import `unittest` module.
  - Create a test class `TestParser` derived from `unittest.TestCase`.
  - Move the test functions inside the `TestParser` class.
  - Add `if __name__ == "__main__": unittest.main()` at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/20?shareId=1726c2fc-3cf8-41cc-b83b-95ba1b3acdde).