### PR TITLE
Fix user input handling in gherkin_parser.py and inspectFeature.py

### DIFF
--- a/gherkin_parser.py
+++ b/gherkin_parser.py
@@ -55,11 +55,9 @@ def parse_feature_file(file_path):
         elif line:
             closest_match = find_closest_match(line, valid_keywords)
             if closest_match:
-                user_input = input(f"Did you mean '{closest_match}' instead of '{line}'? (yes/no): ")
-                if user_input.lower() == 'yes':
-                    update_feature_file(file_path, line_number, closest_match)
-                    return parse_feature_file(file_path)
-            errors.append(f"Invalid Gherkin syntax at line {line_number}: {line}")
+                errors.append(f"Invalid Gherkin syntax at line {line_number}: {line}. Did you mean '{closest_match}'?")
+            else:
+                errors.append(f"Invalid Gherkin syntax at line {line_number}: {line}")
 
     return {
         'features': features,

--- a/inspectFeature.py
+++ b/inspectFeature.py
@@ -44,5 +44,12 @@ def main():
         restore_backup(feature_file_path)
         print("Changes have been undone.")
 
+    user_input = input("Do you want to update the feature file? (yes/no): ")
+    if user_input.lower() == 'yes':
+        line_number = int(input("Enter the line number to update: "))
+        new_line = input("Enter the new line content: ")
+        update_feature_file(feature_file_path, line_number, new_line)
+        print("Feature file updated.")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Remove user input prompt from `parse_feature_file` function in `gherkin_parser.py`.

* **gherkin_parser.py**:
  - Remove user input prompt from `parse_feature_file` function.
  - Modify `parse_feature_file` to only detect errors and append them to the errors list.

* **inspectFeature.py**:
  - Add user input handling for invalid Gherkin syntax.
  - Prompt user to update the feature file and call `update_feature_file` as needed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/23?shareId=b590296c-b8ce-4dea-a0b1-f5b1a93b47dc).