### PR TITLE
Ensure undo changes prompt is shown after all errors are processed

### DIFF
--- a/inspectFeature.py
+++ b/inspectFeature.py
@@ -39,17 +39,17 @@ def main():
     if not feature_data['errors']:
         print("The feature file is clean.")
 
-    user_input = input("Do you want to undo the changes? (yes/no): ")
-    if user_input.lower() == 'yes':
-        restore_backup(feature_file_path)
-        print("Changes have been undone.")
-
     user_input = input("Do you want to update the feature file? (yes/no): ")
     if user_input.lower() == 'yes':
         line_number = int(input("Enter the line number to update: "))
         new_line = input("Enter the new line content: ")
         update_feature_file(feature_file_path, line_number, new_line)
         print("Feature file updated.")
+
+    user_input = input("Do you want to undo the changes? (yes/no): ")
+    if user_input.lower() == 'yes':
+        restore_backup(feature_file_path)
+        print("Changes have been undone.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Move the undo changes prompt to after all errors have been processed in `inspectFeature.py`.

* Move the undo changes prompt to after displaying errors, warnings, and processing all errors.
* Ensure the undo changes prompt appears only after displaying errors, warnings, and processing all errors.
* Update the code to ensure all errors are processed before showing the undo changes prompt.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FeatureFile2Fibery/pull/25?shareId=854b0755-41e7-4b43-8daf-9af5f22f8f5f).